### PR TITLE
chore: editorial change to use family instead of tags

### DIFF
--- a/CIPs/CIP-11/CIP-11.md
+++ b/CIPs/CIP-11/CIP-11.md
@@ -89,6 +89,7 @@ As mentioned previously a *definition* is a document created by a developer to d
 * `description` - A short description that describes the data set in a few sentences
 * `schema` - A DocID of a schema document that has to be set on the *reference*
 * `url` - An url where more information about this data set can be found (optional)
+* `family` - The family to set for the reference document
 * `config` - An object with configurations needed for this data set (optional)
 
 The `config` object can be used for whatever is prefered by the creator of the data set. For example it might be useful to store additional schemas for the data set, urls where the data can be found, DocIDs of service providers that pin the data, etc.
@@ -118,6 +119,10 @@ The `config` object can be used for whatever is prefered by the creator of the d
       "type": "string",
       "maxLength": 240
     },
+    "family": {
+      "type": "string",
+      "maxLength": 240
+    },
     "config": {
       "type": "object"
     }
@@ -128,13 +133,25 @@ The `config` object can be used for whatever is prefered by the creator of the d
       "pattern": "^ceramic://.+(\\?version=.+)?",
       "maxLength": 150
     }
-  }
+  },
+  "required": [
+    "name",
+    "description",
+    "schema"
+  ]
 }
 ```
 
 ### References
 
-A *reference* is created for the user when an application requests access to a new data set. Each user gets their own unique reference that contains information about their individual data, which they control, in the data set. The reference may contain the  data directly, or contain pointers to data that exists elsewhere. When a reference is created the schema is set to the DocID defined in the *reference*.
+A *reference* is created for the user when an application requests access to a new data set. Each user gets their own unique reference that contains information about their individual data, which they control, in the data set. The reference may contain the  data directly, or contain pointers to data that exists elsewhere. 
+
+When creating a reference the following steps should be taken:
+
+1. Create a new *tile* document with `family` set to the DocID of the *definition* and `controller` set to the users DID
+2. Update the document by setting the `schema` to the DocID defined in the `definition`, and the desired content
+
+This enables the reference to be looked up by only knowing the DocID of the definition and the DID of the user.
 
 ---
 

--- a/CIPs/CIP-19/CIP-19.md
+++ b/CIPs/CIP-19/CIP-19.md
@@ -41,7 +41,7 @@ The Basic Profile is simply a *definition* where the reference holds the data of
   "description": "Basic profile information for a DID",
   "schema": "<reference-schema-DocID>",
   "config": {
-    "tags": ["BasicProfile"]
+    "family": "BasicProfile"
   }
 }
 ```
@@ -138,9 +138,9 @@ The Basic Profile schema defines the format of a document that contains the prop
 }
 ```
 
-### Tags
+### Family
 
-In the config of the *definition* defined above we can see a `tags` property. We simply apply the tags in the config to the `tags` property in the *metadata* of the *reference* Tile.
+In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
 
 ## **Example**
 
@@ -150,7 +150,7 @@ An example of how to create a Basic Profile document with js-ceramic.
 const profile = await ceramic.createDocument('tile', {
   metadata: {
     schema: "<reference-schema-DocID>"
-    tags: ["BasicProfile"]
+    family: "BasicProfile"
   },
   content: {
     name: "Samantha Smith",

--- a/CIPs/CIP-19/CIP-19.md
+++ b/CIPs/CIP-19/CIP-19.md
@@ -40,9 +40,6 @@ The Basic Profile is simply a *definition* where the reference holds the data of
   "name": "Basic Profile",
   "description": "Basic profile information for a DID",
   "schema": "<reference-schema-DocID>",
-  "config": {
-    "family": "BasicProfile"
-  }
 }
 ```
 
@@ -138,10 +135,6 @@ The Basic Profile schema defines the format of a document that contains the prop
 }
 ```
 
-### Family
-
-In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
-
 ## **Example**
 
 An example of how to create a Basic Profile document with js-ceramic.
@@ -150,7 +143,7 @@ An example of how to create a Basic Profile document with js-ceramic.
 const profile = await ceramic.createDocument('tile', {
   metadata: {
     schema: "<reference-schema-DocID>"
-    family: "BasicProfile"
+    family: "<definition-DocID>"
   },
   content: {
     name: "Samantha Smith",

--- a/CIPs/CIP-20/CIP-20.md
+++ b/CIPs/CIP-20/CIP-20.md
@@ -61,10 +61,7 @@ The past seeds array contain JWEs that includes previous seeds, which since have
 {
   "name": "3ID Keychain",
   "description": "Key data for 3ID",
-  "schema": "<reference-schema-DocID>",
-  "config": {
-    "family": "3ID Keychain"
-  }
+  "schema": "<reference-schema-DocID>"
 }
 ```
 
@@ -146,10 +143,6 @@ The past seeds array contain JWEs that includes previous seeds, which since have
 }
 ```
 
-### Family
-
-In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
-
 ### Example
 
 An example Crypto Accounts *reference* document that includes two Ethereum accounts and one Bitcoin account.
@@ -158,7 +151,7 @@ An example Crypto Accounts *reference* document that includes two Ethereum accou
 const profile = await ceramic.createDocument('tile', {
   metadata: {
     schema: "<reference-schema-DocID>",
-    family: "3ID Keychain"
+    family: "<definition-DocID>"
   },
   content: {
     "authMap": {

--- a/CIPs/CIP-20/CIP-20.md
+++ b/CIPs/CIP-20/CIP-20.md
@@ -62,6 +62,9 @@ The past seeds array contain JWEs that includes previous seeds, which since have
   "name": "3ID Keychain",
   "description": "Key data for 3ID",
   "schema": "<reference-schema-DocID>",
+  "config": {
+    "family": "3ID Keychain"
+  }
 }
 ```
 
@@ -143,6 +146,10 @@ The past seeds array contain JWEs that includes previous seeds, which since have
 }
 ```
 
+### Family
+
+In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
+
 ### Example
 
 An example Crypto Accounts *reference* document that includes two Ethereum accounts and one Bitcoin account.
@@ -150,7 +157,8 @@ An example Crypto Accounts *reference* document that includes two Ethereum accou
 ```js
 const profile = await ceramic.createDocument('tile', {
   metadata: {
-    schema: "<reference-schema-DocID>"
+    schema: "<reference-schema-DocID>",
+    family: "3ID Keychain"
   },
   content: {
     "authMap": {

--- a/CIPs/CIP-21/CIP-21.md
+++ b/CIPs/CIP-21/CIP-21.md
@@ -46,10 +46,7 @@ The Crypto Accounts is a *definition* that contains a map from CAIP-10 account-i
 {
   "name": "Crypto Accounts",
   "description": "Crypto accounts linked to your DID",
-  "schema": "<reference-schema-DocID>",
-  "config": {
-    "family": "CryptoAccounts"
-  }
+  "schema": "<reference-schema-DocID>"
 }
 ```
 
@@ -72,10 +69,6 @@ The Crypto Accounts is a *definition* that contains a map from CAIP-10 account-i
 }
 ```
 
-### Tags
-
-In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
-
 ### Example
 
 An example Crypto Accounts *reference* document that includes two Ethereum accounts and one Bitcoin account.
@@ -84,7 +77,7 @@ An example Crypto Accounts *reference* document that includes two Ethereum accou
 const profile = await ceramic.createDocument('tile', {
   metadata: {
     schema: "<reference-schema-DocID>"
-    family: "CryptoAccounts"
+    family: "<definition-DocID>"
   },
   content: {
     "0xab16a96d359ec26a11e2c2b3d8nmn8942d5bxzmn@eip155:1": "ceramic://bafyljsdf1...",

--- a/CIPs/CIP-21/CIP-21.md
+++ b/CIPs/CIP-21/CIP-21.md
@@ -48,7 +48,7 @@ The Crypto Accounts is a *definition* that contains a map from CAIP-10 account-i
   "description": "Crypto accounts linked to your DID",
   "schema": "<reference-schema-DocID>",
   "config": {
-    "tags": ["CryptoAccounts"]
+    "family": "CryptoAccounts"
   }
 }
 ```
@@ -74,7 +74,7 @@ The Crypto Accounts is a *definition* that contains a map from CAIP-10 account-i
 
 ### Tags
 
-In the config of the *definition* defined above we can see a `tags` property. We simply apply the tags in the config to the `tags` property in the *metadata* of the *reference* Tile.
+In the config of the *definition* defined above we can see a `family` property. We simply apply the family in the config to the `family` property in the *metadata* of the *reference* Tile.
 
 ### Example
 
@@ -84,7 +84,7 @@ An example Crypto Accounts *reference* document that includes two Ethereum accou
 const profile = await ceramic.createDocument('tile', {
   metadata: {
     schema: "<reference-schema-DocID>"
-    tags: ["CryptoAccounts"]
+    family: "CryptoAccounts"
   },
   content: {
     "0xab16a96d359ec26a11e2c2b3d8nmn8942d5bxzmn@eip155:1": "ceramic://bafyljsdf1...",

--- a/CIPs/CIP-5/CIP-5.md
+++ b/CIPs/CIP-5/CIP-5.md
@@ -60,6 +60,7 @@ enum AnchorStatus {
 interface DocMetadata {
   owners: Array<string>;
   schema?: String;
+  family?: String;
   tags?: Array<string>;
   isUnique?: boolean;
 

--- a/CIPs/CIP-8/CIP-8.md
+++ b/CIPs/CIP-8/CIP-8.md
@@ -60,6 +60,7 @@ When the genesis record is applied a `DocState` object is created that looks lik
   metadata: {
     owners: genesisRecord.owners,
     schema: genesisRecord.schema,
+    family: genesisRecord.family,
     tags: genesisRecord.tags
   },
   content: genesisRecord.data,
@@ -89,6 +90,7 @@ state.next = {
   content: applyJSONPatch(state.content, signedRecord.data),
   metadata: {
     schema: signedRecord.schema,
+    family: genesisRecord.family,
     tags: signedRecord.tags
   }
 }


### PR DESCRIPTION
Use family in place of tags for definitions and references.