### PR TITLE
Image metadata for basic profile

### DIFF
--- a/CIPs/CIP-19/CIP-19.md
+++ b/CIPs/CIP-19/CIP-19.md
@@ -50,10 +50,10 @@ The Basic Profile schema defines the format of a document that contains the prop
 | Property           | Description                    | Value                                                        | Max Size | Required | Example                      |
 | ------------------ | ------------------------------ | ------------------------------------------------------------ | -------- | -------- | ---------------------------- |
 | `name`             | a name                         | string                                                       | 150 char | optional | Mary Smith                   |
-| `image`            | an image                       | IPFS CID URI                                                 |          | optional |                              |
+| `image`            | an image                       | Image metadata                                               |          | optional |                              |
 | `description`      | a short description            | string                                                       | 420 char | optional | This is my cool description. |
 | `emoji`            | an emoji                       | unicode                                                      | 2 char   | optional | 🔢                            |
-| `background`       | a background image (3:1 ratio) | IPFS CID URI                                                 |          | optional |                              |
+| `background`       | a background image (3:1 ratio) | Image metadata                                               |          | optional |                              |
 | `birthDate`        | a date of birth                | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)           | 10 char  | optional | 1990-04-24                   |
 | `url`              | a url                          | string                                                       | 240 char | optional | http://ceramic.network       |
 | `gender`           | a gender                       | string                                                       | 42 char  | optional | female                       |
@@ -74,6 +74,43 @@ The Basic Profile schema defines the format of a document that contains the prop
       "type": "string",
       "pattern": "^ipfs://.+",
       "maxLength": 150
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "imageMetadata": {
+      "type": "object",
+      "properties": {
+        "src": {
+          "$ref": "#/definitions/IPFSUrl"
+        },
+        "width": {
+          "$ref": "#/definitions/positiveInteger"
+        },
+        "height": {
+          "$ref": "#/definitions/positiveInteger"
+        },
+        "size": {
+          "$ref": "#/definitions/positiveInteger"
+        }
+      },
+      "required": ["src", "width", "height"]
+    },
+    "imageSources": {
+      "type": "object",
+      "properties": {
+        "original": {
+          "$ref": "#/definitions/imageMetadata"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/imageMetadata"
+          }
+        }
+      },
+      "required": ["original"]
     }
   },
   "properties": {
@@ -82,7 +119,7 @@ The Basic Profile schema defines the format of a document that contains the prop
       "maxLength": 150
     },
     "image": {
-      "$ref": "#/definitions/IPFSUrl"
+      "$ref": "#/definitions/imageSources"
     },
     "description": {
       "type": "string",
@@ -93,7 +130,7 @@ The Basic Profile schema defines the format of a document that contains the prop
       "maxLength": 2
     },
     "background": {
-      "$ref": "#/definitions/IPFSUrl"
+      "$ref": "#/definitions/imageSources"
     },
     "birthDate": {
       "type": "string",
@@ -121,7 +158,7 @@ The Basic Profile schema defines the format of a document that contains the prop
       "items": {
         "type": "string",
         "pattern": "^[A-Z]{2}$",
-  			"maxItems": 5
+        "maxItems": 5
       }
     },
     "affiliations": {
@@ -147,10 +184,16 @@ const profile = await ceramic.createDocument('tile', {
   },
   content: {
     name: "Samantha Smith",
-  	image: "ipfs://bafy...",
-  	description: "This is my funny description.",
-  	emoji: "🚀",
-  	url: "http://ceramic.network"
+    image: {
+      original: {
+        src: "ipfs://bafy...",
+        width: 500,
+        height: 200
+      }
+    },
+    description: "This is my funny description.",
+    emoji: "🚀",
+    url: "http://ceramic.network"
   }
 })
 ```

--- a/CIPs/CIP-19/CIP-19.md
+++ b/CIPs/CIP-19/CIP-19.md
@@ -50,10 +50,10 @@ The Basic Profile schema defines the format of a document that contains the prop
 | Property           | Description                    | Value                                                        | Max Size | Required | Example                      |
 | ------------------ | ------------------------------ | ------------------------------------------------------------ | -------- | -------- | ---------------------------- |
 | `name`             | a name                         | string                                                       | 150 char | optional | Mary Smith                   |
-| `image`            | an image                       | Image metadata                                               |          | optional |                              |
+| `image`            | an image                       | Image sources                                                |          | optional |                              |
 | `description`      | a short description            | string                                                       | 420 char | optional | This is my cool description. |
 | `emoji`            | an emoji                       | unicode                                                      | 2 char   | optional | 🔢                            |
-| `background`       | a background image (3:1 ratio) | Image metadata                                               |          | optional |                              |
+| `background`       | a background image (3:1 ratio) | Image sources                                                |          | optional |                              |
 | `birthDate`        | a date of birth                | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)           | 10 char  | optional | 1990-04-24                   |
 | `url`              | a url                          | string                                                       | 240 char | optional | http://ceramic.network       |
 | `gender`           | a gender                       | string                                                       | 42 char  | optional | female                       |

--- a/CIPs/CIP-19/CIP-19.md
+++ b/CIPs/CIP-19/CIP-19.md
@@ -85,6 +85,10 @@ The Basic Profile schema defines the format of a document that contains the prop
         "src": {
           "$ref": "#/definitions/IPFSUrl"
         },
+        "mimeType": {
+          "type": "string",
+          "maxLength": 50
+        },
         "width": {
           "$ref": "#/definitions/positiveInteger"
         },
@@ -95,7 +99,7 @@ The Basic Profile schema defines the format of a document that contains the prop
           "$ref": "#/definitions/positiveInteger"
         }
       },
-      "required": ["src", "width", "height"]
+      "required": ["src", "mimeType", "width", "height"]
     },
     "imageSources": {
       "type": "object",
@@ -187,6 +191,7 @@ const profile = await ceramic.createDocument('tile', {
     image: {
       original: {
         src: "ipfs://bafy...",
+        mimeType: "image/png",
         width: 500,
         height: 200
       }


### PR DESCRIPTION
As discussed with @oed, this would replace the need for a custom IPFS-based solution to support multiple image formats, instead allowing to reference multiple sources directly in the basic profile schema.