### PR TITLE
fix: Don't use top level arrays in json-schemas

### DIFF
--- a/CIPs/CIP-11/CIP-11.md
+++ b/CIPs/CIP-11/CIP-11.md
@@ -12,7 +12,7 @@ edited: 2020-09-28
 
 ## Simple Summary
 
-**Identity Index (IDX)** is a standard for constructing an identity-centric index of data sets. It allows developers to define **definitions** for which each user gets a unique **reference**.
+**Identity Index (IDX)** is a standard for constructing an identity-centric index of data sets. It allows developers to define **definitions** for which each user gets a unique **record**.
 </br>
 
 ![IDX Banner Image](https://uploads-ssl.webflow.com/5ebcbef3ac4954196dcdc7b5/5f1ee5131c541e1cdb87c121_idkthin2.jpg)
@@ -31,7 +31,7 @@ Identity Index (IDX) is a standard for constructing an identity-centric index of
 
 By standardizing how data sets are associated to a DID, IDX solves discovery, routing, and resolution. This enables any app to lookup a DID and seamlessly interact with its resources regardless of where they exist or which application first created the data. As a result, IDX can unlock true identity-centric interoperability across the web.
 
-IDX achieves this by specifying data set **definitions** and **references**. A definition is created by a developer to describe a data set for their application. When a user arrives at the application a unique reference is created for the data set as defined in the definition. This means that each user will get a unique reference which they control access and privacy for, while only one global definition exists for any given data set.
+IDX achieves this by specifying data set **definitions** and **records**. A definition is created by a developer to describe a data set for their application. When a user arrives at the application a unique record is created for the data set as defined in the definition. This means that each user will get a unique record which they control access and privacy for, while only one global definition exists for any given data set.
 
 ## Motivation
 
@@ -47,17 +47,17 @@ IDX aims to:
 
 ## Specification
 
-IDX is a Ceramic document which contains mappings from **definitions** to **references**. A *definition* is a Ceramic document created by a developer that describes a *data set*. This document contains a title and description, as well as a schema document that the *reference* has to conform to. In addition to this, the *definition* document may also include configuration options unique to the given data set. A *reference* is also a Ceramic document which has to use the schema defined in the *reference*. This document may contain data directly, but it could also contain pointers to data that lives elsewhere (e.g. in other Ceramic document, on other p2p databases, or hosted databases). Each user should only ever have one instance of any unique *definition*.
+IDX is a Ceramic document which contains mappings from **definitions** to **records**. A *definition* is a Ceramic document created by a developer that describes a *data set*. This document contains a title and description, as well as a schema document that the *record* has to conform to. In addition to this, the *definition* document may also include configuration options unique to the given data set. A *record* is also a Ceramic document which has to use the schema defined in the *record*. This document may contain data directly, but it could also contain pointers to data that lives elsewhere (e.g. in other Ceramic document, on other p2p databases, or hosted databases). Each user should only ever have one instance of any unique *definition*.
 
-The *definition-reference* pair can be stored publicly or encrypted. The former is desirable for data sets which require public discoverability. The latter is useful when possession of the data set should be kept secret. The encrypted *reference* should be encrypted using a unique symmetric key. This enables the data set to be selectively disclosed by asymmetrically encrypting the symmetric key to a given recipient.
+The *definition-record* pair can be stored publicly or encrypted. The former is desirable for data sets which require public discoverability. The latter is useful when possession of the data set should be kept secret. The encrypted *record* should be encrypted using a unique symmetric key. This enables the data set to be selectively disclosed by asymmetrically encrypting the symmetric key to a given recipient.
 
 ![IDX Example](./assets/idx-example.png)
 
 ### IDX Document
 
-The IDX document simply consist of a map from strings to DocIDs. For public data sets the *key* in this map is the DocID (without the prepended `ceramic://`) of the *definition* document, and the *value* is the DocID (with `ceramic://`) of the *reference* document.
+The IDX document simply consist of a map from strings to DocIDs. For public data sets the *key* in this map is the DocID (without the prepended `ceramic://`) of the *definition* document, and the *value* is the DocID (with `ceramic://`) of the *record* document.
 
-For encrypted data sets the *key* is simply a multibase (base36) encoded string of 24 random bytes. The *value* is the DocID (with `ceramic://`) of the *reference* document with content encryption. See the [Data Set Keychain Definition](#data-set-keychain-definition) section for more more details on how this works.
+For encrypted data sets the *key* is simply a multibase (base36) encoded string of 24 random bytes. The *value* is the DocID (with `ceramic://`) of the *record* document with content encryption. See the [Data Set Keychain Definition](#data-set-keychain-definition) section for more more details on how this works.
 
 #### Schema
 
@@ -87,9 +87,8 @@ As mentioned previously a *definition* is a document created by a developer to d
 
 * `name` - The name of the data set
 * `description` - A short description that describes the data set in a few sentences
-* `schema` - A DocID of a schema document that has to be set on the *reference*
+* `schema` - A DocID of a schema document that has to be set on the *record*
 * `url` - An url where more information about this data set can be found (optional)
-* `family` - The family to set for the reference document
 * `config` - An object with configurations needed for this data set (optional)
 
 The `config` object can be used for whatever is prefered by the creator of the data set. For example it might be useful to store additional schemas for the data set, urls where the data can be found, DocIDs of service providers that pin the data, etc.
@@ -142,22 +141,22 @@ The `config` object can be used for whatever is prefered by the creator of the d
 }
 ```
 
-### References
+### Records
 
-A *reference* is created for the user when an application requests access to a new data set. Each user gets their own unique reference that contains information about their individual data, which they control, in the data set. The reference may contain the  data directly, or contain pointers to data that exists elsewhere. 
+A *record* is created for the user when an application requests access to a new data set. Each user gets their own unique record that contains information about their individual data, which they control, in the data set. The record may contain the  data directly, or contain pointers to data that exists elsewhere. 
 
-When creating a reference the following steps should be taken:
+When creating a record the following steps should be taken:
 
 1. Create a new *tile* document with `family` set to the DocID of the *definition* and `controller` set to the users DID
 2. Update the document by setting the `schema` to the DocID defined in the `definition`, and the desired content
 
-This enables the reference to be looked up by only knowing the DocID of the definition and the DID of the user.
+This enables the record to be looked up by only knowing the DocID of the definition and the DID of the user.
 
 ---
 
 ### IDX Keychain Definition
 
-An encrypted data set was defined above to be stored in the IDX document as a multibase encoded string of 24 random bytes as the *key* and a DocID of the *reference* as *value*. The *reference* document should have all of it's content encrypted with a symmetric key, as defined by [CIP-XX](#). Now, we need a way to find out which 24 byte random value maps to which *definition*. This is what the **IDX Keychain** is used for. It stores an array of JWEs that are encrypted to the public key of the DID of the user which controls the given IDX document. Once decrypted, these JWEs should contain the following information:
+An encrypted data set was defined above to be stored in the IDX document as a multibase encoded string of 24 random bytes as the *key* and a DocID of the *record* as *value*. The *record* document should have all of it's content encrypted with a symmetric key, as defined by [CIP-XX](#). Now, we need a way to find out which 24 byte random value maps to which *definition*. This is what the **IDX Keychain** is used for. It stores an array of JWEs that are encrypted to the public key of the DID of the user which controls the given IDX document. Once decrypted, these JWEs should contain the following information:
 
 ```json
 {
@@ -167,44 +166,50 @@ An encrypted data set was defined above to be stored in the IDX document as a mu
 }
 ```
 
-In the data above the `paths` property allows selective disclosure to apps using [EIP-2844](https://eips.ethereum.org/EIPS/eip-2844). The `contentKey` is used for content encryption in the *reference*, and the *definitionKey* is used to find the correct *reference* DocID in the IDX document.
+In the data above the `paths` property allows selective disclosure to apps using [EIP-2844](https://eips.ethereum.org/EIPS/eip-2844). The `contentKey` is used for content encryption in the *record*, and the *definitionKey* is used to find the correct *record* DocID in the IDX document.
 
-#### Reference schema
+#### Record schema
 
-The **IDX Keychain** specifies the following schema in it's `schema` property, which is used for the *reference* document. This schema simply represents an array of JWEs.
+The **IDX Keychain** specifies the following schema in it's `schema` property, which is used for the *record* document. This schema simply represents an array of JWEs.
 
 **Deployment:** `<data-set-keychain-ref-schema-DocID>`
 
 ```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JWE array",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "properties": {
-      "protected": {
-        "type": "string"
+  "type": "object",
+  "title": "IDXKeychain",
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/EntryJWE" }
+    }
+  },
+  "additionalProperties": false,
+  "required": [ "entries" ],
+  "definitions": {
+    "EntryJWE": {
+      "type": "object",
+      "properties": {
+        "protected": { "type": "string" },
+        "iv": { "type": "string" },
+        "ciphertext": { "type": "string" },
+        "tag": { "type": "string" },
+        "aad": { "type": "string" },
+        "recipients": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "header": { "type": "object" },
+              "encrypted_key": { "type": "string" }
+            },
+            "required": [ "header", "encrypted_key" ]
+          }
+        }
       },
-      "iv": {
-        "type": "string"
-      },
-      "ciphertext": {
-        "type": "string"
-      },
-      "tag": {
-        "type": "string"
-      },
-      "recipients": {
-        "type": "array",
-      }
-    },
-    "required": [
-      "protected",
-      "tag",
-      "ciphertext",
-      "iv"
-    ]
+      "required": [ "protected", "iv", "ciphertext", "tag" ]
+    }
   }
 }
 ```
@@ -225,14 +230,14 @@ The **IDX Keychain** *definition* is created using the data below.
 
 #### Accessing an Encrypted Data Set
 
-If an application want's access to encrypted definition `A` with DocID `docA` they have to request permission using the `did_authenticate` method of **EIP-2844** setting `paths = ["/idx/<docA>"]`. This will allow the app to request the particular JWE in the *IDX Keychain* that corresponds to definition `A`. Request to decrypt any other JWE in the array will result in authentication denied. Once the correct JWE is decryped the app can find the correct *reference* using the `definitionKey`, and decrypt it's content using the `contentKey`.
+If an application want's access to encrypted definition `A` with DocID `docA` they have to request permission using the `did_authenticate` method of **EIP-2844** setting `paths = ["/idx/<docA>"]`. This will allow the app to request the particular JWE in the *IDX Keychain* that corresponds to definition `A`. Request to decrypt any other JWE in the array will result in authentication denied. Once the correct JWE is decryped the app can find the correct *record* using the `definitionKey`, and decrypt it's content using the `contentKey`.
 
 
 ## Rationale
 
 **Global Data Sets:** Developers create *definitions* which describes the data used by their apps. These definitions are publicly discoverable on the Ceramic network, which enables developer to browse existing data sets. New applications can compose multiple existing data sets providing new functionality for users existing data.
 
-**User Centric Control:** Users have personal *references* for each globally defined data set that they use. This allows users to remain in full control of their data, be it public or private. An application developer has no control over data of any individual user.
+**User Centric Control:** Users have personal *records* for each globally defined data set that they use. This allows users to remain in full control of their data, be it public or private. An application developer has no control over data of any individual user.
 
 **Extensibility & Flexibility:** It is impossible to predict all of the types of resources that need to be associated with any particular DID. Therefore IDX was designed to be infinitely extensible by allowing developers to create data sets for any kind of resources.
 
@@ -246,25 +251,9 @@ If an application want's access to encrypted definition `A` with DocID `docA` th
 
 ## Security Considerations
 
-The main security consideration here is the encrypted *references*. Since the content encryption of each individual document is defined by [CIP-XX](#) we won't go into detail about that here. The array of JWEs in the *IDX Keychain* does add a bit of overhead since the app can not know beforehand which JWE to decrypt and have to try all of them. This is considered acceptable for now since it allows us to not compromise on security and privacy. Additional protocols for more efficient selective disclosure of data sets can be considered in future CIPs or updates to **EIP-2844**.
+The main security consideration here is the encrypted *records*. Since the content encryption of each individual document is defined by [CIP-XX](#) we won't go into detail about that here. The array of JWEs in the *IDX Keychain* does add a bit of overhead since the app can not know beforehand which JWE to decrypt and have to try all of them. This is considered acceptable for now since it allows us to not compromise on security and privacy. Additional protocols for more efficient selective disclosure of data sets can be considered in future CIPs or updates to **EIP-2844**.
 
-## Suggested Usages
-
-Discoverability and use cases.
-
-### DIDs
-
-IDX does not provide a DID but can be used with any DID. To use IDX, simply store the DocId of the IDX document in the DID document. Specifically an entry in the `service` array of the DID document.
-
-```js
-{
-  id: "<DID>#idx",
-  type: "IdentityIndexRoot",
-  serviceEndpoint: "<IDX-DocID>",
-}
-```
-
-### Example Definitions
+## Example Definitions
 
 Below you can find a list of a few example definitions.
 

--- a/CIPs/CIP-23/CIP-23.md
+++ b/CIPs/CIP-23/CIP-23.md
@@ -61,14 +61,23 @@ The reference schema defines a document which maintains an array of JSON objects
 
 **Deployment:** `<reference-schema-DocID>`
 
-```jsx
+```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "array",
+  "type": "object",
   "title": "AlsoKnownAs",
-  "items": {
-    "$ref": "#/definitions/Account"
+  "properties": {
+    "accounts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Account"
+      }
+    }
   },
+  "additionalProperties": false,
+  "required": [
+    "accounts"
+  ],
   "definitions": {
     "Attestation": {
       "type": "object",
@@ -128,21 +137,23 @@ const profile = await ceramic.createDocument('tile', {
     schema: "<reference-schema-DocID>"
     family: "<definition-DocID>"
   },
-  content: [{
-    protocol: "https",
-    host: "twitter.com",
-    id: "marysmith",
-    // ID of tweet containing the user's DID
-    claim: "https://twitter.com/marysmith/status/1274020265417076736",
-    attestations: [{ did-jwt-vc: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }]
-  }, {
-    protocol: "https",
-    host: "github.com",
-    id: "marysmith",
-    // ID of Gist containing the user's DID
-    claim: "https://gist.github.com/marysmith/5c48debdb7089b3c8f86cca31739572c",
-    attestations: [{ did-jwt-vc: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }]
-  }]
+  content: {
+    accounts: [{
+      protocol: "https",
+      host: "twitter.com",
+      id: "marysmith",
+      // ID of tweet containing the user's DID
+      claim: "https://twitter.com/marysmith/status/1274020265417076736",
+      attestations: [{ did-jwt-vc: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }]
+    }, {
+      protocol: "https",
+      host: "github.com",
+      id: "marysmith",
+      // ID of Gist containing the user's DID
+      claim: "https://gist.github.com/marysmith/5c48debdb7089b3c8f86cca31739572c",
+      attestations: [{ did-jwt-vc: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }]
+    }]
+  }
 })
 ```
 


### PR DESCRIPTION
Changes CIP-11 and CIP-23 to not use top level arrays in the json-schema since that's not compatible with json-patch.

Also threw in some editorial changes to the IDX CIP.