### PR TITLE
switched the labels for x25519 and secp256k1

### DIFF
--- a/CIPs/CIP-79/CIP-79.md
+++ b/CIPs/CIP-79/CIP-79.md
@@ -75,8 +75,8 @@ const doc = await ceramic.createDocument({
   },
   content: {
     publicKeys: {
-      "XQCT2xJHsdY6iJH": "z6LSqKWh3XQ7AfsJuE2KR23cozEut8D5CXQCT2xJHsdY6iJH",  // secp256k1 public key
-      "yh27jTt7Ny2Pwdy": "zQ3shrMGEKAjUTMmvDkcZ7Y3x9XnVjTH3myh27jTt7Ny2Pwdy", // x25519 public key
+      "XQCT2xJHsdY6iJH": "z6LSqKWh3XQ7AfsJuE2KR23cozEut8D5CXQCT2xJHsdY6iJH",  // x22519 public key
+      "yh27jTt7Ny2Pwdy": "zQ3shrMGEKAjUTMmvDkcZ7Y3x9XnVjTH3myh27jTt7Ny2Pwdy", // secp256k1 public key
     }
   },
   deterministic: true


### PR DESCRIPTION
I changed the labeling for secp256k1 and x25519 to be in line with https://w3c-ccg.github.io/did-method-key/ . 

I used code https://gist.github.com/bshambaugh/e3730a24cf1f87813c32f7e7f41a1179 . I noticed that x25519 was only 31 bytes rather than 32.