### PR TITLE
Update Ceramic metadata field to use $comment field

### DIFF
--- a/CIPs/CIP-82/CIP-82.md
+++ b/CIPs/CIP-82/CIP-82.md
@@ -1,6 +1,6 @@
 ---
 cip: 82
-title: DocID json-schema definition
+title: StreamID json-schema definition
 author: Paul Le Cam (@PaulLeCam)
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/82
 status: Draft
@@ -13,15 +13,15 @@ requires: [CIP-88](https://github.com/ceramicnetwork/CIP/issues/88)
 
 ## Simple Summary
 
-Provide a static way to define a string in a JSON schema represents a Ceramic DocID, optionally with static references to the schema(s) that must be used by the referenced document.
+Provide a static way to define a string in a JSON schema represents a Ceramic StreamID, optionally with static references to the schema(s) that must be used by the referenced stream.
 
 ## Abstract
 
-This CIP defines a standard way to add a reference to an existing Ceramic document in a JSON schema and references to existing JSON schemas, so it is possible to access this information about Ceramic documents at build time rather than only at runtime on created documents.
+This CIP defines a standard way to add a reference to an existing Ceramic stream in a JSON schema and references to existing JSON schemas, so it is possible to access this information about Ceramic streams at build time rather than only at runtime on created streams.
 
 ## Motivation
 
-It is sometimes necessary to reference Ceramic documents from other documents, such as a list containing the docIDs of individual Ceramic documents.
+It is sometimes necessary to reference Ceramic streams from other streams, such as a list containing the streamIDs of individual Ceramic streams.
 Currently, we are sometimes using definitions that can be referenced in a schema using `"$ref": "#/definitions/CeramicDocId"` for example, but this has not be defined as a standard.
 Using local definitions to a schema also has the downside of providing no guaranty of being unique or having the definition matching any standard.
 
@@ -57,10 +57,7 @@ Using this CIP, a `NotesList` schema could explicitly reference a `Note` schema 
     NoteDocID: {
       type: 'string',
       maxLength: 150,
-      $ceramic: {
-        type: 'tile',
-        schema: '<Note schema docID>',
-      },
+      $comment: 'ceramic:tile:<Note schema streamID>',
     },
   },
 }
@@ -70,25 +67,23 @@ This way, by loading the `Notes` schema, it is possible by a tool/library to dis
 
 ## Specification
 
-References to Ceramic schema should use a `string` with the `$ceramic` field using the `tile` type, and optionally with a `schema` property containing either a string or array of strings containing the DocID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s):
+References to Ceramic schema should use a `string` with the `$comment` field using the `ceramic:tile` type, and optionally with a schema string of the StreamID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s).
+Multiple schemas can be provided, using the `|` character as separator.
 
 ```js
 {
   type: 'string',
   maxLength: 150,
-  $ceramic: {
-    type: 'tile',
-    schema: '<Note schema docID>',
-  },
+  $comment: 'ceramic:tile:<Note schema streamID>',
 }
 ```
 
 ## Rationale
 
-This CIP uses the `$ceramic` namespace defined in [CIP-88](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-88/CIP-88.md).
+This CIP uses the `$comment` field as defined in [CIP-88](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-88/CIP-88.md).
 
 This spec allows to either define a single schema (using a string) or multiple ones (array of strings).
-The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `schema: ['<image schema docID>', '<audio schema docID>', '<video schema docID>']`.
+The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `$comment: 'ceramic:tile:<image schema docID>|<audio schema docID>|<video schema docID>'`.
 
 ## Backwards Compatibility
 

--- a/CIPs/CIP-82/CIP-82.md
+++ b/CIPs/CIP-82/CIP-82.md
@@ -57,7 +57,7 @@ Using this CIP, a `NotesList` schema could explicitly reference a `Note` schema 
     NoteDocID: {
       type: 'string',
       maxLength: 150,
-      $comment: 'ceramic:tile:<Note schema streamID>',
+      $comment: 'ceramic:doc:<Note schema streamID>',
     },
   },
 }
@@ -67,14 +67,14 @@ This way, by loading the `Notes` schema, it is possible by a tool/library to dis
 
 ## Specification
 
-References to Ceramic schema should use a `string` with the `$comment` field using the `ceramic:tile` type, and optionally with a schema string of the StreamID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s).
+References to Ceramic schema should use a `string` with the `$comment` field using the `ceramic:doc` type, and optionally with a schema string of the StreamID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s).
 Multiple schemas can be provided, using the `|` character as separator.
 
 ```js
 {
   type: 'string',
   maxLength: 150,
-  $comment: 'ceramic:tile:<Note schema streamID>',
+  $comment: 'ceramic:doc:<Note schema streamID>',
 }
 ```
 
@@ -83,7 +83,7 @@ Multiple schemas can be provided, using the `|` character as separator.
 This CIP uses the `$comment` field as defined in [CIP-88](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-88/CIP-88.md).
 
 This spec allows to either define a single schema (using a string) or multiple ones (array of strings).
-The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `$comment: 'ceramic:tile:<image schema docID>|<audio schema docID>|<video schema docID>'`.
+The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `$comment: 'ceramic:doc:<image schema docID>|<audio schema docID>|<video schema docID>'`.
 
 ## Backwards Compatibility
 

--- a/CIPs/CIP-82/CIP-82.md
+++ b/CIPs/CIP-82/CIP-82.md
@@ -7,7 +7,7 @@ status: Draft
 category: Standards
 type: RFC
 created: 2021-02-15
-edited: 2021-03-01
+edited: 2021-07-02
 requires: [CIP-88](https://github.com/ceramicnetwork/CIP/issues/88)
 ---
 
@@ -57,7 +57,7 @@ Using this CIP, a `NotesList` schema could explicitly reference a `Note` schema 
     NoteDocID: {
       type: 'string',
       maxLength: 150,
-      $comment: 'ceramic:doc:<Note schema streamID>',
+      $comment: 'cip88:ref:<Note schema streamID>',
     },
   },
 }
@@ -67,14 +67,14 @@ This way, by loading the `Notes` schema, it is possible by a tool/library to dis
 
 ## Specification
 
-References to Ceramic schema should use a `string` with the `$comment` field using the `ceramic:doc` type, and optionally with a schema string of the StreamID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s).
+References to Ceramic schema should use a `string` with the `$comment` field using the `cip88:ref` type, and optionally with a schema string of the StreamID (implicit reference to latest version) or CommitID (specific version) of the supported schema(s).
 Multiple schemas can be provided, using the `|` character as separator.
 
 ```js
 {
   type: 'string',
   maxLength: 150,
-  $comment: 'ceramic:doc:<Note schema streamID>',
+  $comment: 'cip88:ref:<Note schema streamID>',
 }
 ```
 
@@ -82,8 +82,8 @@ Multiple schemas can be provided, using the `|` character as separator.
 
 This CIP uses the `$comment` field as defined in [CIP-88](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-88/CIP-88.md).
 
-This spec allows to either define a single schema (using a string) or multiple ones (array of strings).
-The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `$comment: 'ceramic:doc:<image schema docID>|<audio schema docID>|<video schema docID>'`.
+This spec allows to either define a single schema or multiple ones sparated by the `|` character.
+The use case would be to support different schemas for a single reference, for example a "media" schema could reference an "image" schema, but also the "audio" and "video" ones as acceptable document schemas: `$comment: 'cip88:ref:<image schema docID>|<audio schema docID>|<video schema docID>'`.
 
 ## Backwards Compatibility
 

--- a/CIPs/CIP-85/CIP-85.md
+++ b/CIPs/CIP-85/CIP-85.md
@@ -17,38 +17,42 @@ Provide schemas and associated tools to help interact with large lists in Cerami
 
 ## Abstract
 
-This CIP presents a way to store a possibly large list of items split into multiple documents based on two complementary schemas: `AppendCollection` and `CollectionSlice`.
-This allows to create a virtually infinite list of items such as a feed by leveraging multiple Ceramic documents rather than a single one.
+This CIP presents a way to store a possibly large list of items split into multiple streams based on two complementary schemas: `AppendCollection` and `CollectionSlice`.
+This allows to create a virtually infinite list of items such as a feed by leveraging multiple Ceramic streams rather than a single one.
 
 ## Motivation
 
-Storing a list of items in a single Ceramic document can make the document grow large in size, possibly exceeding Ceramic's internal limits.
+Storing a list of items in a single Ceramic stream can make the stream grow large in size, possibly exceeding Ceramic's internal limits.
 Providing a standard way to represent large lists such as feeds would be useful to provide reference schemas to solve this issue and associated tools to simplify interactions.
 
 ## Specification
 
 ### Concepts
 
-#### Doc references
+#### Stream references
 
-The schemas use document references defined in [CIP-82](https://github.com/ceramicnetwork/CIP/issues/82) to identify relations.
+The schemas use stream references defined in [CIP-82](https://github.com/ceramicnetwork/CIP/issues/82) to identify relations.
 
 #### Cursors
 
-A cursor is a unique identifier for an item in the collection, made of the tuple (CollectionSlice DocID, item index).
+A cursor is a unique identifier for an item in the collection, made of the tuple (CollectionSlice StreamID, item index).
 A collection slice should contain a maximum of 256 items, so the index of an item in the slice can be represented in a single byte.
+
+#### Slice tag
+
+A slice tag is a string identifying a unique slice part of a collection based on the index of the slice, as: `<collection StreamID string>:<slice index>`.
 
 ### Schemas
 
 Two schemas are needed to represent a collection: the `AppendCollection` schema represents an entry point to the collection, and the `CollectionSlice` schema represents a single slice of the full list of items.
 
-A Collection "instance" would therefore be made of 1 `AppendCollection` document and any number of `CollectionSlice` documents with cross-references, as presented in the graphic below:
+A Collection "instance" would therefore be made of 1 `AppendCollection` stream and any number of `CollectionSlice` streams with cross-references, as presented in the graphic below:
 
 ![Collection relations graphic](./assets/collection-graphic.png)
 
 #### AppendCollection schema
 
-The `AppendCollection` schema must be an `object` with a `$ceramic` field from [CIP-88](../CIP-88/CIP-88.md) having the type `appendCollection` and pointing to the slice's `schema`, along with the following properties:
+The `AppendCollection` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) using the `ceramic:appendCollection` prefix and pointing to the slice's `schema`, along with the following properties:
 
 - `sliceMaxItems`: the maximum number of items a single slice should contain
 - `slicesCount`: the total number of slices the collection contains
@@ -56,7 +60,7 @@ The `AppendCollection` schema must be an `object` with a `$ceramic` field from [
 ```js
 {
   $schema: 'http://json-schema.org/draft-07/schema#',
-  $ceramic: { type: 'appendCollection', sliceSchema: '<slice schema ID>' },
+  $comment: 'ceramic:appendCollection:<slice schema ID>',
   title: 'MyCollection',
   type: 'object',
   properties: {
@@ -69,16 +73,16 @@ The `AppendCollection` schema must be an `object` with a `$ceramic` field from [
 
 #### CollectionSlice schema
 
-The `CollectionSlice` schema must be an `object` with a `$ceramic` field from [CIP-88](../CIP-88/CIP-88.md) having the type `collectionSlice` and pointing to the slice's `schema`, along with the following properties:
+The `CollectionSlice` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) having the value `ceramic:collectionSlice`, along with the following properties:
 
-- `collection`: the DocID of the collection the slice is part of
+- `collection`: the StreamID of the collection the slice is part of
 - `sliceIndex`: index of the slice in the collection, between `0` and the collection's `slicesCount` minus `1`
 - `contents`: array with a `maxItems` value matching the `AppendCollection` `sliceMaxItems` property and defining the items schemas, that must include `{ type: 'null' }` in order to support removals
 
 ```js
 {
   $schema: 'http://json-schema.org/draft-07/schema#',
-  $ceramic: { type: 'collectionSlice' },
+  $comment: 'ceramic:collectionSlice',
   title: 'MyCollectionSlice',
   type: 'object',
   properties: {
@@ -101,37 +105,33 @@ The `CollectionSlice` schema must be an `object` with a `$ceramic` field from [C
 
 #### Deterministic slice access
 
-Accessing slices in the collection relies on Ceramic's ability to load documents deterministically based on their genesis contents:
-
-- `collection`: the collection's `DocID` string
-- `sliceIndex`: the slice's index, an integer between `0` (first slice) and `slicesCount - 1` (last slice)
-- `contents`: empty array
+Accessing slices in the collection relies on Ceramic's ability to load streams deterministically based on their metadata by using `{ deterministic: true, tags: ['<slice tag>'] }`, where `slice tag` is a string of `<collection StreamID string>:<slice index>`.
 
 #### First insertion
 
-> This flow assumes a prerequisite check that the `AppendCollection` document has not been created yet.
+> This flow assumes a prerequisite check that the `AppendCollection` stream has not been created yet.
 
-1. Create the `AppendCollection` document with a `slicesCount` of `1`.
-1. Create a deterministic `CollectionSlice` document with `sliceIndex` of `0` and an empty `contents` array.
-1. Update the created `CollectionSlice` document with the `contents` array containing the item to insert.
+1. Create the `AppendCollection` stream with a `slicesCount` of `1`.
+1. Create a deterministic `CollectionSlice` stream with a tag using the `index` value `0`.
+1. Update the created `CollectionSlice` stream with the `collection` string, `sliceIndex` number and `contents` array containing the item to insert.
 
 #### Other insertions
 
-1. Load the `AppendCollection` document.
-1. Load the most recent `CollectionSlice` document based on its deterministic content, using the `slicesCount` from the collection.
+1. Load the `AppendCollection` stream.
+1. Load the most recent `CollectionSlice` stream based on its deterministic content, using the `slicesCount` from the collection.
 1. Check the length of the `contents` array of the `CollectionSlice`:
 
 - If it is lower than the `sliceMaxItems` value of the `AppendCollection`, add the item to the `contents` array.
 - If it is equal to the `sliceMaxItems` value:
-  1. Create a new deterministic `CollectionSlice` document with `sliceIndex` equal to the `sliceIndex` of the previous slice plus `1` and an empty `contents` array.
-  1. Update the created `CollectionSlice` document with the `contents` array containing the item to insert.
-  1. Update the `AppendCollection` document with the incremented `slicesCount`.
+  1. Create a new deterministic `CollectionSlice` stream with `index` value of the previous slice plus `1`.
+  1. Update the created `CollectionSlice` stream with the `collection` string, `sliceIndex` number and `contents` array containing the item to insert.
+  1. Update the `AppendCollection` stream with the incremented `slicesCount`.
 
 #### Single item loading
 
-Loading a single item is based on the item cursor (slice DocID + item index in slice):
+Loading a single item is based on the item cursor (slice StreamID + item index in slice):
 
-1. Load the `CollectionSlice` document from its DocID.
+1. Load the `CollectionSlice` stream from its StreamID.
 1. Access the item at the given index in the `contents` array.
 
 #### Multiple item loading
@@ -140,27 +140,27 @@ Loading multiple items can be done in order (from the `first` slice) or reverse 
 
 - `first: N`
 
-  1. Load the `CollectionSlice` document based on its determistic content with a `sliceIndex` of `0`.
+  1. Load the `CollectionSlice` stream based on its determistic content with a `sliceIndex` of `0`.
   1. Iterate through `contents` filtering out `null` values until `N` items are collected.
   1. If `N` items are not collected, load the next slice deterministically and continue from previous step.
 
 - `first: N, after: cursor(slice ID, offset)`
 
-  1. Load the `CollectionSlice` document from the `slice ID`.
+  1. Load the `CollectionSlice` stream from the `slice ID`.
   1. Skip the first `contents` items according to the `offset`.
   1. Iterate through `contents` filtering out `null` values until `N` items are collected.
   1. If `N` items are not collected, load the next slice deterministically and continue from previous step.
 
 - `last: N`
 
-  1. Load the `AppendCollection` document.
-  1. Load the `CollectionSlice` document based on its determistic content, using the `slicesCount` from the collection.
+  1. Load the `AppendCollection` stream.
+  1. Load the `CollectionSlice` stream based on its determistic content, using the `slicesCount` from the collection.
   1. Iterate through `contents` in reverse order filtering out `null` values until `N` items are collected.
   1. If `N` items are not collected and the first slice is not reached, load the previous slice deterministically and continue from previous step
 
 - `last: N, before: cursor(slice ID, offset)`
 
-  1. Load the `CollectionSlice` document from the `slice ID`.
+  1. Load the `CollectionSlice` stream from the `slice ID`.
   1. Skip the first `contents` items according to the `offset`.
   1. Iterate through `contents` in reverse order filtering out `null` values until `N` items are collected.
   1. If `N` items are not collected and the first slice is not reached, load the previous slice deterministically and continue from previous step
@@ -169,7 +169,7 @@ Loading multiple items can be done in order (from the `first` slice) or reverse 
 
 Removing an item consists in replacing the item value by `null` in the `contents` array identified by the given `cursor(slice ID, offset)`:
 
-1. Load the `CollectionSlice` document from the `slice ID`.
+1. Load the `CollectionSlice` stream from the `slice ID`.
 1. Access the item from the `contents` array at the given `offset`.
 1. If the item exists, replace it by `null`.
 
@@ -189,7 +189,7 @@ None yet.
 
 ## Security Considerations
 
-The spec defines clear expectations about the number of items a slice can contain, and how cursors should be stable, but as with any other Ceramic document, it is up to the schema validation and correct spec implementations to ensure the correct behavior is applied.
+The spec defines clear expectations about the number of items a slice can contain, and how cursors should be stable, but as with any other Ceramic stream, it is up to the schema validation and correct spec implementations to ensure the correct behavior is applied.
 
 ## Copyright
 

--- a/CIPs/CIP-85/CIP-85.md
+++ b/CIPs/CIP-85/CIP-85.md
@@ -7,7 +7,7 @@ status: Draft
 category: Standards
 type: RFC
 created: 2021-02-16
-edited: 2021-03-02
+edited: 2021-07-02
 requires: [CIP-82](https://github.com/ceramicnetwork/CIP/issues/82), [CIP-88](https://github.com/ceramicnetwork/CIP/issues/88)
 ---
 
@@ -22,7 +22,7 @@ This allows to create a virtually infinite list of items such as a feed by lever
 
 ## Motivation
 
-Storing a list of items in a single Ceramic stream can make the stream grow large in size, possibly exceeding Ceramic's internal limits.
+Storing a list of items in a single Ceramic Tile stream can make the stream grow large in size, possibly exceeding Ceramic's internal limits for this stream stype.
 Providing a standard way to represent large lists such as feeds would be useful to provide reference schemas to solve this issue and associated tools to simplify interactions.
 
 ## Specification
@@ -52,7 +52,7 @@ A Collection "instance" would therefore be made of 1 `AppendCollection` stream a
 
 #### AppendCollection schema
 
-The `AppendCollection` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) using the `ceramic:appendCollection` prefix and pointing to the slice's `schema`, along with the following properties:
+The `AppendCollection` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) using the `cip88:appendCollection` prefix and pointing to the slice's `schema`, along with the following properties:
 
 - `sliceMaxItems`: the maximum number of items a single slice should contain
 - `slicesCount`: the total number of slices the collection contains
@@ -60,7 +60,7 @@ The `AppendCollection` schema must be an `object` with a `$comment` field from [
 ```js
 {
   $schema: 'http://json-schema.org/draft-07/schema#',
-  $comment: 'ceramic:appendCollection:<slice schema ID>',
+  $comment: 'cip88:appendCollection:<slice schema ID>',
   title: 'MyCollection',
   type: 'object',
   properties: {
@@ -73,7 +73,7 @@ The `AppendCollection` schema must be an `object` with a `$comment` field from [
 
 #### CollectionSlice schema
 
-The `CollectionSlice` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) having the value `ceramic:collectionSlice`, along with the following properties:
+The `CollectionSlice` schema must be an `object` with a `$comment` field from [CIP-88](../CIP-88/CIP-88.md) having the value `cip88:collectionSlice`, along with the following properties:
 
 - `collection`: the StreamID of the collection the slice is part of
 - `sliceIndex`: index of the slice in the collection, between `0` and the collection's `slicesCount` minus `1`
@@ -82,7 +82,7 @@ The `CollectionSlice` schema must be an `object` with a `$comment` field from [C
 ```js
 {
   $schema: 'http://json-schema.org/draft-07/schema#',
-  $comment: 'ceramic:collectionSlice',
+  $comment: 'cip88:collectionSlice',
   title: 'MyCollectionSlice',
   type: 'object',
   properties: {

--- a/CIPs/CIP-88/CIP-88.md
+++ b/CIPs/CIP-88/CIP-88.md
@@ -6,6 +6,7 @@ status: Draft
 category: Standards
 type: RFC
 created: 2021-03-01
+edited: 2021-07-02
 ---
 
 ## Simple Summary
@@ -27,7 +28,7 @@ Instead, this CIP relies on the `$comment` field that is supported by AJV's stri
 
 ### Namespace
 
-A JSON schema property can contain a `$comment` field, that must be a string starting with `ceramic:`:
+A JSON schema property can contain a `$comment` field, that must be a string starting with `cip88:`:
 
 ```js
 {
@@ -49,9 +50,9 @@ A JSON schema property can contain a `$comment` field, that must be a string sta
 
 Using the `$comment` property allows to add a metadata string to a schema in a spec-compliant way (compatible with AJV's strict mode).
 
-The string value must match the following pattern: `ceramic:<type>[type-specific string]`.
+The string value must match the following pattern: `cip88:<type>[type-specific string]`.
 
-A unique `type`, possibly followed by an additional type-specific string, should make it easy to add custom extensions and build tools based on having the `$comment` value start with `ceramic:`.
+A unique `type`, possibly followed by an additional type-specific string, should make it easy to add custom extensions and build tools based on having the `$comment` value start with `cip88:`.
 
 Finally, providing a reference table in this CIP should allow for easy discovery and avoid conflicts between extensions.
 

--- a/CIPs/CIP-88/CIP-88.md
+++ b/CIPs/CIP-88/CIP-88.md
@@ -18,22 +18,22 @@ This CIP defines a reserved namespace for Ceramic-specific metadata in a JSON sc
 
 ## Motivation
 
-As commented in https://github.com/ceramicnetwork/CIP/issues/82#issuecomment-787449788 the `$id` cannot be used to define Ceramic-specific extensions as intended in [CIP-82](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md), so creating a custom namespace for Ceramic-specific metadata should be a safer option to enable further extensions.
+As commented in https://github.com/ceramicnetwork/CIP/issues/82#issuecomment-787449788 the `$id` cannot be used to define Ceramic-specific extensions as intended in [CIP-82](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md).
+
+A previous version of this CIP relied on creating a custom namespace for Ceramic-specific metadata using the non-standard `$ceramic` key, but it was not compatible with the "strict mode" of the JSON validation library used in Ceramic (AJV).
+Instead, this CIP would rely on the `$comment` field that is supported by AJV's strict mode.
 
 ## Specification
 
 ### Namespace
 
-A JSON schema property can contain a `$ceramic` field, that must be an object with a unique `type` defined in the following reference table, for example:
+A JSON schema property can contain a `$comment` field, that must be a string starting with `ceramic:`:
 
 ```js
 {
   type: 'string',
   maxLength: 150,
-  $ceramic: {
-    type: 'tile',
-    schema: '<schema docID or commitID>' ,
-  },
+  $comment: 'ceramic:tile:<schema streamID or commitID>',
 }
 ```
 
@@ -47,9 +47,11 @@ A JSON schema property can contain a `$ceramic` field, that must be an object wi
 
 ## Rationale
 
-Using the `$ceramic` property should be consistent with other `$`-prefixed metadata properties in JSON schemas, avoiding possible conflicts with other property names.
+Using the `$comment` property allows to add a metadata string to a schema in a spec-compliant way (compatible with AJV's strict mode).
 
-A unique `type`, along with possible type-specific additional properties, should make it easy to add custom extensions and build tools (simple checks for existence of `$ceramic` property and type-specific logic, TypeScript interfaces and inference, etc.).
+The string value must match the following pattern: `ceramic:<type>[type-specific string]`.
+
+A unique `type`, possibly followed by an additional type-specific string, should make it easy to add custom extensions and build tools based on having the `$comment` value start with `ceramic:`.
 
 Finally, providing a reference table in this CIP should allow for easy discovery and avoid conflicts between extensions.
 

--- a/CIPs/CIP-88/CIP-88.md
+++ b/CIPs/CIP-88/CIP-88.md
@@ -39,11 +39,11 @@ A JSON schema property can contain a `$comment` field, that must be a string sta
 
 ### Reference table
 
-| Type               | CIP                                                                                                   | Status |
-| ------------------ | ----------------------------------------------------------------------------------------------------- | ------ |
-| `tile`             | [DocID json-schema definition](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md) | Draft  |
-| `appendCollection` | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)     | Draft  |
-| `collectionSlice`  | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)     | Draft  |
+| Type               | CIP                                                                                                      | Status |
+| ------------------ | -------------------------------------------------------------------------------------------------------- | ------ |
+| `doc`              | [StreamID json-schema definition](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md) | Draft  |
+| `appendCollection` | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)        | Draft  |
+| `collectionSlice`  | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)        | Draft  |
 
 ## Rationale
 

--- a/CIPs/CIP-88/CIP-88.md
+++ b/CIPs/CIP-88/CIP-88.md
@@ -6,7 +6,7 @@ status: Draft
 category: Standards
 type: RFC
 created: 2021-03-01
-edited: 2021-07-02
+edited: 2021-09-07
 ---
 
 ## Simple Summary
@@ -34,7 +34,7 @@ A JSON schema property can contain a `$comment` field, that must be a string sta
 {
   type: 'string',
   maxLength: 150,
-  $comment: 'ceramic:tile:<schema streamID or commitID>',
+  $comment: 'ceramic:ref:<schema streamID or commitID>',
 }
 ```
 
@@ -42,7 +42,7 @@ A JSON schema property can contain a `$comment` field, that must be a string sta
 
 | Type               | CIP                                                                                                      | Status |
 | ------------------ | -------------------------------------------------------------------------------------------------------- | ------ |
-| `doc`              | [StreamID json-schema definition](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md) | Draft  |
+| `ref`              | [StreamID json-schema definition](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md) | Draft  |
 | `appendCollection` | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)        | Draft  |
 | `collectionSlice`  | [AppendCollection schemas](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-85/CIP-85.md)        | Draft  |
 

--- a/CIPs/CIP-88/CIP-88.md
+++ b/CIPs/CIP-88/CIP-88.md
@@ -21,7 +21,7 @@ This CIP defines a reserved namespace for Ceramic-specific metadata in a JSON sc
 As commented in https://github.com/ceramicnetwork/CIP/issues/82#issuecomment-787449788 the `$id` cannot be used to define Ceramic-specific extensions as intended in [CIP-82](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-82/CIP-82.md).
 
 A previous version of this CIP relied on creating a custom namespace for Ceramic-specific metadata using the non-standard `$ceramic` key, but it was not compatible with the "strict mode" of the JSON validation library used in Ceramic (AJV).
-Instead, this CIP would rely on the `$comment` field that is supported by AJV's strict mode.
+Instead, this CIP relies on the `$comment` field that is supported by AJV's strict mode.
 
 ## Specification
 


### PR DESCRIPTION
- Uses `$comment` instead of `$ceramic` field in JSON schemas
- Replaces mentions of document/DocID by stream/StreamID
- Uses `tags` metadata for deterministic slice access for append-collection