### PR TITLE
Fix copypaste statement in CIP-20.md

### DIFF
--- a/CIPs/CIP-20/CIP-20.md
+++ b/CIPs/CIP-20/CIP-20.md
@@ -143,6 +143,7 @@ The past seeds array contain JWEs that includes previous seeds, which since have
 ```
 
 ### Example
+An example 3ID Keychain record document.
 
 ```js
 const profile = await ceramic.createDocument('tile', {

--- a/CIPs/CIP-20/CIP-20.md
+++ b/CIPs/CIP-20/CIP-20.md
@@ -144,8 +144,6 @@ The past seeds array contain JWEs that includes previous seeds, which since have
 
 ### Example
 
-An example Crypto Accounts *record* document that includes two Ethereum accounts and one Bitcoin account.
-
 ```js
 const profile = await ceramic.createDocument('tile', {
   metadata: {


### PR DESCRIPTION
`An example Crypto Accounts *record* document that includes two Ethereum accounts and one Bitcoin account.` is super confusing here and it seems to be a copypaste error from https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-21/CIP-21.md, and in the original context(cip-21) it actually made sense

```
Example
An example Crypto Accounts record document that includes two Ethereum accounts and one Bitcoin account.

const profile = await ceramic.createDocument('tile', {
  metadata: {
    schema: "<record-schema-DocID>"
    family: "<definition-DocID>"
  },
  content: {
    "0xab16a96d359ec26a11e2c2b3d8nmn8942d5bxzmn@eip155:1": "ceramic://bafyljsdf1...",
    "0xzx45a83d123ec26a11e2c2b3d8f8b8942d5bfcdb@eip155:1": "ceramic://bafyljsdf2...",
    "128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6@bip122:000000000019d6689c085ae165831e93": "ceramic://bafysdfoijwe3..."
  }
})
```