### PR TITLE
Update NFT DID to be purely generative.

### DIFF
--- a/CIPs/cip-94.md
+++ b/CIPs/cip-94.md
@@ -4,8 +4,7 @@ title: NFT DID Method Specification
 author: Joel Thorstensson (@oed)
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/95
 status: Draft
-category: Standards
-type: RFC
+category: RFC
 created: 2021-02-12
 updated: 2023-04-21
 ---
@@ -44,7 +43,7 @@ Mint an NFT on any blockchain.
 
 Extract the Asset ID from the method specific identifier. 
 
-#### Ethereum ERC20
+#### Ethereum ERC721
 
 Given a DID with the `erc721` token namespace,
 


### PR DESCRIPTION
This PR simplifies the NFT DID specification by a lot. This is achieved by making it purely generative. In order to use NFT DID going forward an object-capability in the form of a ChainProof would be needed to be used. This greatly reduces the complexity of the NFT DID overall since a Ceramic node would no longer need to rely on an external Blockchain indexer.

[📑 Preview](https://github.com/ceramicnetwork/CIP/blob/feat/update-nft-did/CIPs/cip-94.md)